### PR TITLE
fix: バージョンアップに伴うHook位置の変更

### DIFF
--- a/app/src/main/java/org/soralis_0912/mpa/bypass/Main.java
+++ b/app/src/main/java/org/soralis_0912/mpa/bypass/Main.java
@@ -17,7 +17,7 @@ public class Main implements IXposedHookLoadPackage {
             return;
         }
 
-        XposedHelpers.findAndHookMethod("j.a.a.a.b.a", lpparam.classLoader, "l", new XC_MethodHook() {
+        XposedHelpers.findAndHookMethod("p6.a", lpparam.classLoader, "l", new XC_MethodHook() {
 
             @Override
             protected void afterHookedMethod(MethodHookParam param) throws Throwable {


### PR DESCRIPTION
## Why
- ver. 78 →  ver. 80でHookすべきメソッドの位置が変わっていたため

## What
- ver. 80の場合はHookする位置を`j.a.a.a.b.a`から`p6.a`に変更